### PR TITLE
Verify wb is not null before dereference

### DIFF
--- a/ckpool/src/stratifier.c
+++ b/ckpool/src/stratifier.c
@@ -8650,7 +8650,7 @@ static void db_log_share(sdata_t* sdata, json_t* val, workbase_t* wb) {
         return;
 
     /* Convert numeric values to strings */
-    snprintf(height_str, sizeof(height_str), "%d", wb->height);
+    snprintf(height_str, sizeof(height_str), "%d", !wb ? 0 : wb->height);
     snprintf(workinfoid_str, sizeof(workinfoid_str), "%lld", json_integer_value(json_object_get(val, "workinfoid")));
     snprintf(clientid_str, sizeof(clientid_str), "%lld", json_integer_value(json_object_get(val, "clientid")));
     snprintf(diff_str, sizeof(diff_str), "%f", json_real_value(json_object_get(val, "diff")));


### PR DESCRIPTION
Diagnostic Path:
Last message in error logs prior to segmentation fault
`Rejected client 327 invalid share Invalid JobID`

That specific error `Invalid JobID` is associated with the share error code `SE_INVALID_JOBID` which is only assigned in stratifier on line 6015 if the wb is null (!wb). As such when we attempt to dereference wb to access `wb->height` we know with certainty that it will not exist. This is the assumed failure mode.


Proposed Solution:
Check if wb is null before deref. Use height 0 otherwise (height doesn't matter as share is already rejected).