### PR TITLE
Point To Official Rust Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Setup
 
 ### Requirements:
 
-* [Rust](#manual-install)
+* [Rust](https://rust-lang.org/tools/install/)
 * [Just](https://github.com/casey/just?tab=readme-ov-file#installation)
 
 #### Manual Install


### PR DESCRIPTION
Another minor suggestion for the `README`.

In the requirements section, I think it would be wise to include a link to the official rust install docs instead just a navigation-link to the `Manual Install` sub section just below it - which is perhaps semi-redundant anyway, since the user is already reading through the `README`.

As we open-source this repo and more people use the `README` for installation guidance, it's good to point users to official download resources with alternative methods suited for their OS/use-case (example of the official page attached) when noting explicit requirements outside of the rust crate - especially for those less familiar with programming/CLI usage, so they don't accidentally find an unofficial download source in the wild. This also validates where the command provided in the `Manual Install` section comes from ♥

This was already done for the  `just` requirement (which has a link to it's actual repo), so I believe this change would be consistent with the documentation format.

<img width="1313" height="749" alt="image" src="https://github.com/user-attachments/assets/b51ad911-b7d9-4ed8-b6e6-c753601ca2ad" />
