### PR TITLE
feat: expose cumulative round work (total_work) per participant

### DIFF
--- a/bin/postgres-init
+++ b/bin/postgres-init
@@ -113,12 +113,18 @@ PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -c "
       idx_remote_shares_blockheight ON
       remote_shares (blockheight);
   "
-# Covering index for round participation queries (index-only scans)
+# Covering index for round participation queries (index-only scans).
+# Covers both sdiff (MAX top_diff) and diff (SUM total_work). Drop the older
+# sdiff-only variant first so existing deployments pick up the wider INCLUDE.
+if ! PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -tAc \
+    "SELECT indexdef FROM pg_indexes WHERE indexname='idx_remote_shares_round_participation'" | grep -q 'sdiff, diff'; then
+  PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -c "DROP INDEX CONCURRENTLY IF EXISTS idx_remote_shares_round_participation;"
+fi
 PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -c "
   CREATE INDEX CONCURRENTLY IF NOT EXISTS
       idx_remote_shares_round_participation ON
       remote_shares (blockheight, username)
-      INCLUDE (sdiff)
+      INCLUDE (sdiff, diff)
       WHERE reject_reason IS NULL;
   "
 
@@ -275,18 +281,38 @@ PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -c "
       username TEXT NOT NULL,
       blocks_participated BIGINT NOT NULL,
       top_diff DOUBLE PRECISION NOT NULL,
+      total_work DOUBLE PRECISION NOT NULL DEFAULT 0,
       PRIMARY KEY (blockheight, username)
   )
   "
+# Migration: add total_work to existing history tables. Truncate so previously
+# snapshotted rounds are lazily recomputed (with work) from remote_shares on next read.
+if ! PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -tAc \
+    "SELECT 1 FROM pg_attribute WHERE attrelid='round_participation_history'::regclass AND attname='total_work' AND NOT attisdropped" | grep -q 1; then
+  PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -c "
+    ALTER TABLE round_participation_history ADD COLUMN total_work DOUBLE PRECISION NOT NULL DEFAULT 0;
+    TRUNCATE round_participation_history;
+  "
+fi
 
-# Materialized view for current (in-progress) round participation
+# Materialized view for current (in-progress) round participation.
+# Recreate it if it is missing, or if it predates the total_work column (schema migration).
+RECREATE_MATVIEW=0
 if ! PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -tAc "SELECT 1 FROM pg_matviews WHERE matviewname='round_participation_current'" | grep -q 1; then
+  RECREATE_MATVIEW=1
+elif ! PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -tAc \
+    "SELECT 1 FROM pg_attribute WHERE attrelid='round_participation_current'::regclass AND attname='total_work' AND NOT attisdropped" | grep -q 1; then
+  PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -c "DROP MATERIALIZED VIEW round_participation_current;"
+  RECREATE_MATVIEW=1
+fi
+if [ "$RECREATE_MATVIEW" = "1" ]; then
   PGPASSWORD="nakamoto" psql -h localhost -U satoshi -d ckpool -c "
     CREATE MATERIALIZED VIEW round_participation_current AS
     SELECT
         COALESCE(rs.username, '') AS username,
         COUNT(DISTINCT rs.blockheight)::BIGINT AS blocks_participated,
-        COALESCE(MAX(rs.sdiff), 0) AS top_diff
+        COALESCE(MAX(rs.sdiff), 0) AS top_diff,
+        COALESCE(SUM(rs.diff), 0) AS total_work
     FROM remote_shares rs
     WHERE rs.blockheight > (SELECT COALESCE(MAX(blockheight), 0) FROM blocks)
         AND rs.reject_reason IS NULL

--- a/src/subcommand/server/database.rs
+++ b/src/subcommand/server/database.rs
@@ -811,7 +811,7 @@ impl Database {
                 // 'current' round comes from matview
                 match sqlx::query_as::<_, RoundParticipant>(
                     "
-                    SELECT username, blocks_participated, top_diff
+                    SELECT username, blocks_participated, top_diff, total_work
                     FROM round_participation_current
                     ORDER BY top_diff DESC
                     ",
@@ -850,7 +850,7 @@ impl Database {
     ) -> Result<Vec<RoundParticipant>, sqlx::Error> {
         sqlx::query_as::<_, RoundParticipant>(
             "
-            SELECT username, blocks_participated, top_diff
+            SELECT username, blocks_participated, top_diff, total_work
             FROM round_participation_history
             WHERE blockheight = $1
             ORDER BY top_diff DESC
@@ -875,7 +875,8 @@ impl Database {
             SELECT
                 COALESCE(rs.username, '') AS username,
                 COUNT(DISTINCT rs.blockheight) AS blocks_participated,
-                COALESCE(MAX(rs.sdiff), 0) AS top_diff
+                COALESCE(MAX(rs.sdiff), 0) AS top_diff,
+                COALESCE(SUM(rs.diff), 0) AS total_work
             FROM remote_shares rs, previous_block pb
             WHERE rs.blockheight > pb.prev_height
                 AND ($1::INTEGER IS NULL OR rs.blockheight <= $1)
@@ -893,7 +894,7 @@ impl Database {
     pub(crate) async fn snapshot_round_participation(&self, blockheight: i32) -> Result<()> {
         sqlx::query(
             "
-            INSERT INTO round_participation_history (blockheight, username, blocks_participated, top_diff)
+            INSERT INTO round_participation_history (blockheight, username, blocks_participated, top_diff, total_work)
             WITH previous_block AS (
                 SELECT COALESCE(MAX(b.blockheight), 0) AS prev_height
                 FROM blocks b
@@ -903,7 +904,8 @@ impl Database {
                 $1,
                 COALESCE(rs.username, ''),
                 COUNT(DISTINCT rs.blockheight),
-                COALESCE(MAX(rs.sdiff), 0)
+                COALESCE(MAX(rs.sdiff), 0),
+                COALESCE(SUM(rs.diff), 0)
             FROM remote_shares rs, previous_block pb
             WHERE rs.blockheight > pb.prev_height
                 AND rs.blockheight <= $1

--- a/src/subcommand/server/rounds.rs
+++ b/src/subcommand/server/rounds.rs
@@ -14,6 +14,8 @@ pub(crate) struct RoundParticipant {
     pub(crate) username: String,
     pub(crate) blocks_participated: i64,
     pub(crate) top_diff: f64,
+    /// Cumulative accepted work (sum of share difficulties) for this user in the round.
+    pub(crate) total_work: f64,
 }
 
 pub(crate) fn rounds_router(database: Database) -> axum::Router {

--- a/tests/server_with_db.rs
+++ b/tests/server_with_db.rs
@@ -1144,7 +1144,9 @@ async fn test_current_round() {
     let foo = participants.iter().find(|p| p.username == "foo").unwrap();
     assert_eq!(foo.blocks_participated, 1);
     assert_eq!(foo.top_diff, 2000.0);
-    assert_eq!(foo.total_work, 3000.0);
+    // Only the height-7 share counts; the height-3 share is from the previous
+    // round (block 5 was found), matching blocks_participated == 1 above.
+    assert_eq!(foo.total_work, 2000.0);
 
     let bar = participants.iter().find(|p| p.username == "bar").unwrap();
     assert_eq!(bar.blocks_participated, 1);

--- a/tests/server_with_db.rs
+++ b/tests/server_with_db.rs
@@ -11,6 +11,7 @@ struct RoundParticipant {
     username: String,
     blocks_participated: i64,
     top_diff: f64,
+    total_work: f64,
 }
 
 async fn insert_test_shares_for_round(
@@ -1045,14 +1046,17 @@ async fn test_round_participants() {
     let foo = participants.iter().find(|p| p.username == "foo").unwrap();
     assert_eq!(foo.blocks_participated, 2);
     assert_eq!(foo.top_diff, 3000.0);
+    assert_eq!(foo.total_work, 4000.0);
 
     let bar = participants.iter().find(|p| p.username == "bar").unwrap();
     assert_eq!(bar.blocks_participated, 1);
     assert_eq!(bar.top_diff, 5000.0);
+    assert_eq!(bar.total_work, 5000.0);
 
     let baz = participants.iter().find(|p| p.username == "baz").unwrap();
     assert_eq!(baz.blocks_participated, 1);
     assert_eq!(baz.top_diff, 2000.0);
+    assert_eq!(baz.total_work, 2000.0);
 }
 
 #[tokio::test]
@@ -1098,6 +1102,7 @@ async fn test_round_first_includes_all_prior_shares() {
     assert_eq!(participants.len(), 1);
     assert_eq!(participants[0].blocks_participated, 3);
     assert_eq!(participants[0].top_diff, 300.0);
+    assert_eq!(participants[0].total_work, 600.0);
 }
 
 #[tokio::test]
@@ -1139,10 +1144,12 @@ async fn test_current_round() {
     let foo = participants.iter().find(|p| p.username == "foo").unwrap();
     assert_eq!(foo.blocks_participated, 1);
     assert_eq!(foo.top_diff, 2000.0);
+    assert_eq!(foo.total_work, 3000.0);
 
     let bar = participants.iter().find(|p| p.username == "bar").unwrap();
     assert_eq!(bar.blocks_participated, 1);
     assert_eq!(bar.top_diff, 500.0);
+    assert_eq!(bar.total_work, 500.0);
 }
 
 #[tokio::test]

--- a/tests/test_psql.rs
+++ b/tests/test_psql.rs
@@ -314,6 +314,7 @@ pub(crate) async fn setup_test_schema(db_url: String) -> Result<(), Box<dyn std:
                     username TEXT NOT NULL,
                     blocks_participated BIGINT NOT NULL,
                     top_diff DOUBLE PRECISION NOT NULL,
+                    total_work DOUBLE PRECISION NOT NULL DEFAULT 0,
                     PRIMARY KEY (blockheight, username)
                 )
                 "#,
@@ -335,7 +336,8 @@ pub(crate) async fn setup_test_schema(db_url: String) -> Result<(), Box<dyn std:
                 SELECT
                     COALESCE(rs.username, '') AS username,
                     COUNT(DISTINCT rs.blockheight)::BIGINT AS blocks_participated,
-                    COALESCE(MAX(rs.sdiff), 0) AS top_diff
+                    COALESCE(MAX(rs.sdiff), 0) AS top_diff,
+                    COALESCE(SUM(rs.diff), 0) AS total_work
                 FROM remote_shares rs
                 WHERE rs.blockheight > (SELECT COALESCE(MAX(blockheight), 0) FROM blocks)
                     AND rs.reject_reason IS NULL


### PR DESCRIPTION
## Summary

Adds a `total_work` field to the round-participation endpoints: the **counted** cumulative accepted work (sum of share difficulty, `SUM(diff)`) each user contributed in a round, alongside the existing `top_diff` (which is `MAX(sdiff)`, i.e. best share).

This is the real, counted work — the same quantity the PPLNS payout path already sums. Exposing it means consumers (parastats) no longer have to *estimate* work by integrating hashrate samples over time. Summed across the current round it is also the pool-wide work since the last block.

## What changed

- `RoundParticipant` gains `total_work`, populated from `COALESCE(SUM(diff), 0)` with the same `reject_reason IS NULL` accepted-share filter used for `top_diff`.
- Updated all four code paths in `database.rs`: the current-round materialized view query, the history-table read, the live fallback query, and the history snapshot insert.
- `bin/postgres-init`:
  - `round_participation_history` gets a `total_work` column.
  - `round_participation_current` matview now selects `SUM(diff)`.
  - Covering index `idx_remote_shares_round_participation` widened to `INCLUDE (sdiff, diff)` so `SUM(diff)` stays an index-only scan.
- All schema changes are **idempotent migrations** so existing deployments upgrade in place:
  - history table: `ADD COLUMN` if missing, then `TRUNCATE` once so previously-snapshotted rounds lazily recompute *with* work from `remote_shares` on next read.
  - matview: dropped & recreated only if it predates the column.
  - index: dropped & recreated only if it doesn't already cover `diff`.

## Notes

- `SUM(diff)` is robust to the `compress_shares` compaction (which already stores `SUM(diff)` per worker+blockheight), so historical rounds compute correctly.
- `diff` (credited difficulty) is the right column for "work" — it matches the PPLNS `SUM(diff)` and is in difficulty-1-share-equivalent units.

## Testing

- `cargo build --tests` and `cargo fmt --check` pass.
- Extended the round-participation integration tests (`tests/server_with_db.rs`) to assert `total_work` for historical and current rounds; test schema in `tests/test_psql.rs` updated to match. (DB integration tests are `cfg(linux)`, so they run in CI.)
