### PR TITLE
Add display_name to account metadata and a bulk /names endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[Unreleased]
+------------
+
+### Added
+- Add `display_name` to account metadata: accounts can set an optional,
+  non-unique cosmetic name via the existing signed `/account/metadata`
+  endpoint (validated: trimmed, max 24 chars, no control characters). Names are
+  surfaced on the `Account` response and through a new bulk `/names` endpoint
+  (address -> name) for front-ends to consume. Accounts marked `is_private` are
+  excluded from `/names`.
+
 [0.5.4](https://github.com/parasitepool/para/releases/tag/0.5.4) - 2026-06-25
 -----------------------------------------------------------------------------
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -126,6 +126,7 @@ impl Modify for SecurityAddon {
         account::account_lookup,
         account::account_update,
         account::account_metadata_update,
+        account::names_lookup,
         // Share difficulty endpoints
         sharediff::highestdiff,
         sharediff::highestdiff_by_user,

--- a/src/subcommand/server/account.rs
+++ b/src/subcommand/server/account.rs
@@ -1,10 +1,95 @@
 use super::*;
 
-const USER_METADATA_KEYS: &[&str] = &["is_private"];
+/// Metadata keys that hold a boolean (or null to clear).
+const BOOL_METADATA_KEYS: &[&str] = &["is_private"];
+
+/// Metadata keys that hold a free-form string (or null/empty to clear).
+const STRING_METADATA_KEYS: &[&str] = &["display_name"];
+
+/// Maximum length, in characters, of a user-chosen display name. Kept short so
+/// names render cleanly in leaderboards alongside (never instead of) the address.
+const DISPLAY_NAME_MAX_CHARS: usize = 24;
+
+/// Normalize and validate a user-supplied display name.
+///
+/// Returns:
+/// - `Ok(Some(name))` for an accepted, trimmed name,
+/// - `Ok(None)` when the value is null or trims to empty (a request to clear it),
+/// - `Err(())` when the value is present but invalid (wrong type, too long, or
+///   contains control characters).
+///
+/// Names are intentionally *not* required to be unique: they are cosmetic
+/// labels, and the account's BTC address remains its identity everywhere.
+fn sanitize_display_name(value: &serde_json::Value) -> Result<Option<String>, ()> {
+    if value.is_null() {
+        return Ok(None);
+    }
+
+    let raw = value.as_str().ok_or(())?;
+    let trimmed = raw.trim();
+
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    if trimmed.chars().count() > DISPLAY_NAME_MAX_CHARS {
+        return Err(());
+    }
+
+    // Reject control characters (newlines, tabs, etc.) to keep leaderboard
+    // rendering and logs well-behaved. Display escaping is still the renderer's
+    // job; this only blocks obviously abusive input.
+    if trimmed.chars().any(|c| c.is_control()) {
+        return Err(());
+    }
+
+    Ok(Some(trimmed.to_string()))
+}
+
+/// Validate an incoming metadata patch against the allowlists, returning the
+/// sanitized object to persist. Unknown keys are dropped. Returns `Err` (→ 400)
+/// if a recognized key carries an invalid value or nothing valid remains.
+fn validate_metadata(
+    object: &serde_json::Map<String, serde_json::Value>,
+) -> Result<serde_json::Value, ()> {
+    let mut out = serde_json::Map::new();
+
+    for (key, value) in object {
+        if BOOL_METADATA_KEYS.contains(&key.as_str()) {
+            if value.is_boolean() || value.is_null() {
+                out.insert(key.clone(), value.clone());
+            } else {
+                return Err(());
+            }
+        } else if STRING_METADATA_KEYS.contains(&key.as_str()) {
+            match sanitize_display_name(value)? {
+                Some(name) => {
+                    out.insert(key.clone(), serde_json::Value::String(name));
+                }
+                // Explicit clear: store JSON null. Readers (get_account /
+                // display_names) treat null-or-empty as "no name set".
+                None => {
+                    out.insert(key.clone(), serde_json::Value::Null);
+                }
+            }
+        }
+        // Unrecognized keys are silently ignored.
+    }
+
+    if out.is_empty() {
+        return Err(());
+    }
+
+    Ok(serde_json::Value::Object(out))
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, ToSchema)]
 pub struct Account {
     pub btc_address: String,
+    /// Optional cosmetic display name, surfaced on leaderboards and account
+    /// pages. Never unique and never a substitute for `btc_address`, which
+    /// remains the account identity. Derived from `metadata.display_name`.
+    pub display_name: Option<String>,
     pub ln_address: Option<String>,
     pub past_ln_addresses: Vec<String>,
     pub total_diff: i64,
@@ -42,6 +127,7 @@ pub(crate) fn account_router(database: Database) -> axum::Router {
             "/account/metadata",
             post(account_metadata_update).layer(DefaultBodyLimit::max(1024)),
         )
+        .route("/names", get(names_lookup))
         .layer(from_extractor::<ApiAuth>())
         .layer(Extension(database))
 }
@@ -147,21 +233,9 @@ pub(crate) async fn account_metadata_update(
         return Ok(StatusCode::BAD_REQUEST.into_response());
     };
 
-    let filtered: serde_json::Map<String, serde_json::Value> = object
-        .iter()
-        .filter(|(key, _)| USER_METADATA_KEYS.contains(&key.as_str()))
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
-
-    if filtered.is_empty() {
+    let Ok(filtered) = validate_metadata(object) else {
         return Ok(StatusCode::BAD_REQUEST.into_response());
-    }
-
-    if !filtered.values().all(|v| v.is_boolean() || v.is_null()) {
-        return Ok(StatusCode::BAD_REQUEST.into_response());
-    }
-
-    let filtered = serde_json::Value::Object(filtered);
+    };
 
     database
         .update_account_metadata(&metadata_update.btc_address, &filtered)
@@ -169,6 +243,28 @@ pub(crate) async fn account_metadata_update(
         .ok_or_not_found(|| "Account")
         .map(Json)
         .map(IntoResponse::into_response)
+}
+
+/// Bulk lookup of display names.
+///
+/// Returns a JSON object mapping BTC address -> display name for every account
+/// that has set one. Intended to be fetched once by front-ends (e.g. the
+/// leaderboard) and merged client-side, so that a public dashboard can label
+/// rows with names while still showing the underlying address.
+#[utoipa::path(
+    get,
+    path = "/names",
+    security(("api_token" = [])),
+    responses(
+        (status = 200, description = "Map of address to display name"),
+    ),
+    tag = "account"
+)]
+pub(crate) async fn names_lookup(
+    Extension(database): Extension<Database>,
+) -> ServerResult<Response> {
+    let names = database.display_names().await?;
+    Ok(Json(names).into_response())
 }
 
 pub fn verify_signature(address: &str, message: &str, signature: &String) -> bool {
@@ -197,5 +293,61 @@ pub fn verify_signature(address: &str, message: &str, signature: &String) -> boo
             }
         }
         Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_and_trims_a_normal_name() {
+        assert_eq!(
+            sanitize_display_name(&json!("  Satoshi  ")),
+            Ok(Some("Satoshi".to_string()))
+        );
+    }
+
+    #[test]
+    fn null_or_empty_clears_the_name() {
+        assert_eq!(sanitize_display_name(&json!(null)), Ok(None));
+        assert_eq!(sanitize_display_name(&json!("   ")), Ok(None));
+    }
+
+    #[test]
+    fn rejects_overlong_and_control_chars_and_non_strings() {
+        let long: String = "a".repeat(DISPLAY_NAME_MAX_CHARS + 1);
+        assert_eq!(sanitize_display_name(&json!(long)), Err(()));
+        assert_eq!(sanitize_display_name(&json!("bad\nname")), Err(()));
+        assert_eq!(sanitize_display_name(&json!(42)), Err(()));
+    }
+
+    #[test]
+    fn counts_unicode_by_char_not_byte() {
+        // 24 multibyte chars is fine even though it exceeds 24 bytes.
+        let name = "é".repeat(DISPLAY_NAME_MAX_CHARS);
+        assert_eq!(sanitize_display_name(&json!(name)), Ok(Some(name)));
+    }
+
+    #[test]
+    fn validate_metadata_mixes_typed_keys_and_drops_unknowns() {
+        let input = json!({
+            "is_private": true,
+            "display_name": " Alice ",
+            "not_allowed": "ignored"
+        });
+        let out = validate_metadata(input.as_object().unwrap()).unwrap();
+        assert_eq!(out["is_private"], json!(true));
+        assert_eq!(out["display_name"], json!("Alice"));
+        assert!(out.get("not_allowed").is_none());
+    }
+
+    #[test]
+    fn validate_metadata_rejects_bad_types_and_empty_patches() {
+        // is_private must be boolean/null.
+        assert!(validate_metadata(json!({"is_private": "yes"}).as_object().unwrap()).is_err());
+        // Nothing recognized -> 400.
+        assert!(validate_metadata(json!({"unknown": 1}).as_object().unwrap()).is_err());
     }
 }

--- a/src/subcommand/server/database.rs
+++ b/src/subcommand/server/database.rs
@@ -345,14 +345,52 @@ impl Database {
             return Ok(None);
         };
 
+        let display_name = raw
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("display_name"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+
         Ok(Some(Account {
             btc_address: raw.username,
+            display_name,
             ln_address: raw.lnurl,
             past_ln_addresses: raw.past_lnurls.0,
             total_diff: raw.total_diff,
             last_updated: raw.last_updated,
             metadata: raw.metadata,
         }))
+    }
+
+    /// Return a map of BTC address -> display name for all accounts that have a
+    /// non-empty `display_name` in their metadata. Used to label leaderboards.
+    pub async fn display_names(&self) -> Result<std::collections::HashMap<String, String>> {
+        #[derive(sqlx::FromRow)]
+        struct NameRow {
+            username: String,
+            display_name: String,
+        }
+
+        let rows = sqlx::query_as::<_, NameRow>(
+            "
+            SELECT a.username, TRIM(m.data->>'display_name') AS display_name
+            FROM accounts a
+            JOIN account_metadata m ON a.id = m.account_id
+            WHERE NULLIF(TRIM(m.data->>'display_name'), '') IS NOT NULL
+              AND (m.data->>'is_private') IS DISTINCT FROM 'true'
+            ",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|err| anyhow!(err))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.username, row.display_name))
+            .collect())
     }
 
     pub async fn update_account_lnurl(

--- a/tests/account.rs
+++ b/tests/account.rs
@@ -569,4 +569,75 @@ async fn metadata_update_allowlist() {
     assert_eq!(metadata["is_private"], false);
     assert!(metadata.get("block_count").is_none());
     assert!(metadata.get("highest_blockheight").is_none());
+
+    // ---- display names ----
+
+    // Set a display name; it is trimmed and surfaced on the typed field.
+    let account = case(
+        &server,
+        &test_account,
+        &btc_address,
+        serde_json::json!({"display_name": "  Satoshi  "}),
+        StatusCode::OK,
+    )
+    .await
+    .unwrap();
+    assert_eq!(account.display_name.as_deref(), Some("Satoshi"));
+    assert_eq!(account.metadata.unwrap()["display_name"], "Satoshi");
+
+    // Overlong names are rejected.
+    case(
+        &server,
+        &test_account,
+        &btc_address,
+        serde_json::json!({"display_name": "x".repeat(64)}),
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
+
+    // The bulk /names map exposes address -> name for labeling leaderboards.
+    let names = server
+        .get_json_async::<std::collections::HashMap<String, String>>("/names")
+        .await;
+    assert_eq!(names.get(&btc_address).map(String::as_str), Some("Satoshi"));
+
+    // A private account's name must not be published via /names.
+    case(
+        &server,
+        &test_account,
+        &btc_address,
+        serde_json::json!({"is_private": true}),
+        StatusCode::OK,
+    )
+    .await;
+    let names = server
+        .get_json_async::<std::collections::HashMap<String, String>>("/names")
+        .await;
+    assert!(names.get(&btc_address).is_none());
+
+    // Making it public again re-publishes the name.
+    case(
+        &server,
+        &test_account,
+        &btc_address,
+        serde_json::json!({"is_private": false}),
+        StatusCode::OK,
+    )
+    .await;
+    let names = server
+        .get_json_async::<std::collections::HashMap<String, String>>("/names")
+        .await;
+    assert_eq!(names.get(&btc_address).map(String::as_str), Some("Satoshi"));
+
+    // Clearing with an empty string unsets the name.
+    let account = case(
+        &server,
+        &test_account,
+        &btc_address,
+        serde_json::json!({"display_name": ""}),
+        StatusCode::OK,
+    )
+    .await
+    .unwrap();
+    assert_eq!(account.display_name, None);
 }


### PR DESCRIPTION
Backend for #487.

Accounts can set an optional, non-unique cosmetic display name via the existing signed `/account/metadata` endpoint (BIP322/ECDSA — no new auth surface). Backend only: storage, validation, and exposure for front-ends to consume. Stored in the existing `account_metadata` JSONB, so no schema migration; accounts that never set a name are unchanged.

- `account.rs`: typed metadata validation (boolean + string keys), a display-name sanitizer (trim, 24-char cap counted by char, control-char reject, null/empty clears), and a bulk `GET /names` endpoint (address -> name); registered in the OpenAPI doc.
- `database.rs`: derive `display_name` onto the `Account` response and add `display_names()`, which excludes accounts marked `is_private`.
- tests: sanitizer/validator unit tests and an end-to-end metadata + `/names` integration case (including the private-exclusion path).

Scope note: this deliberately does not touch para's built-in server-rendered dashboard templates — user-facing rendering is planned as a companion `parastats` PR once this field exists.

**Verification:** I could not fully build in my environment (needs the bitcoin submodule + Postgres test harness). The `account.rs` unit tests run without a DB; the `/names` + metadata integration tests use the existing Postgres harness. Please run `cargo check` / `cargo test` — happy to fix anything that surfaces.
